### PR TITLE
STEP-1054: Add flaky test

### DIFF
--- a/BullsEye.xcodeproj/project.pbxproj
+++ b/BullsEye.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		202D822D25D7D57B00778080 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		202D823D25D7D8A300778080 /* URLSessionStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionStub.swift; sourceTree = "<group>"; };
 		5394F02421864DF4006E754C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8CEA304E268C706300041FEF /* FlakyTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = FlakyTests.xctestplan; path = BullsEyeSlowTests/FlakyTests.xctestplan; sourceTree = "<group>"; };
 		D2A5F2001F4A9144005CD714 /* BullsEye.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BullsEye.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2A5F2081F4A9144005CD714 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		D2A5F20A1F4A9144005CD714 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -142,6 +143,7 @@
 		D2A5F1F71F4A9143005CD714 = {
 			isa = PBXGroup;
 			children = (
+				8CEA304E268C706300041FEF /* FlakyTests.xctestplan */,
 				13055E73267B39B700D762C7 /* FailingTests.xctestplan */,
 				134E1D48267B31C200FEA165 /* ParallelUITests.xctestplan */,
 				13FB7D17267742220084066F /* UnitTests.xctestplan */,

--- a/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
+++ b/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
@@ -44,6 +44,9 @@
          <TestPlanReference
             reference = "container:FailingTests.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:BullsEyeSlowTests/FlakyTests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/BullsEyeSlowTests/BullsEyeSlowTests.swift
+++ b/BullsEyeSlowTests/BullsEyeSlowTests.swift
@@ -137,3 +137,19 @@ class BullsEyeFailingTests: XCTestCase {
     XCTAssertEqual(statusCode, 200)
   }
 }
+
+class BullsEyeFlakyTests: XCTestCase {
+  
+  static var numberOfFailures = 0
+  
+  override class func setUp() {
+    numberOfFailures = Int(ProcessInfo.processInfo.environment["FLAKY_TEST_NUMBER_OF_FAILURES"] ?? "1") ?? 1
+  }
+  
+  func testPassIfNoFailuresRemain() {
+    if BullsEyeFlakyTests.numberOfFailures > 0 {
+      BullsEyeFlakyTests.numberOfFailures -= 1
+      XCTFail()
+    }
+  }
+}

--- a/BullsEyeSlowTests/FlakyTests.xctestplan
+++ b/BullsEyeSlowTests/FlakyTests.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "6ADB41B7-6F06-4C78-B680-E64A7E89882E",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "BullsEyeFailingTests",
+        "BullsEyeSlowTests"
+      ],
+      "target" : {
+        "containerPath" : "container:BullsEye.xcodeproj",
+        "identifier" : "13FB7CFA2677288A0084066F",
+        "name" : "BullsEyeSlowTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
## Description
**Added flaky test case which succeeds after a certain number of failures**.
* Number of failures can be configured via an environment variable (`FLAKY_TEST_NUMBER_OF_FAILURES`).
* This can be useful to test the test repetition feature in Xcode.