### PR TITLE
Adding flaky test with persistent state

### DIFF
--- a/BullsEye.xcodeproj/project.pbxproj
+++ b/BullsEye.xcodeproj/project.pbxproj
@@ -74,8 +74,8 @@
 		13FB7D18267745440084066F /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		202D822D25D7D57B00778080 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		202D823D25D7D8A300778080 /* URLSessionStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionStub.swift; sourceTree = "<group>"; };
+		47F8605E26932D000039E549 /* FlakyTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FlakyTests.xctestplan; sourceTree = "<group>"; };
 		5394F02421864DF4006E754C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		8CEA304E268C706300041FEF /* FlakyTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = FlakyTests.xctestplan; path = BullsEyeSlowTests/FlakyTests.xctestplan; sourceTree = "<group>"; };
 		D2A5F2001F4A9144005CD714 /* BullsEye.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BullsEye.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2A5F2081F4A9144005CD714 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		D2A5F20A1F4A9144005CD714 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -168,7 +168,7 @@
 		D2A5F1F71F4A9143005CD714 = {
 			isa = PBXGroup;
 			children = (
-				8CEA304E268C706300041FEF /* FlakyTests.xctestplan */,
+				47F8605E26932D000039E549 /* FlakyTests.xctestplan */,
 				13055E73267B39B700D762C7 /* FailingTests.xctestplan */,
 				134E1D48267B31C200FEA165 /* ParallelUITests.xctestplan */,
 				13FB7D17267742220084066F /* UnitTests.xctestplan */,

--- a/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
+++ b/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
@@ -45,7 +45,7 @@
             reference = "container:FailingTests.xctestplan">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:BullsEyeSlowTests/FlakyTests.xctestplan">
+            reference = "container:FlakyTests.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/BullsEyeFailingTests/BullsEyeFailingTests.swift
+++ b/BullsEyeFailingTests/BullsEyeFailingTests.swift
@@ -68,16 +68,13 @@ class BullsEyeFailingTests: XCTestCase {
 }
 
 class BullsEyeFlakyTests: XCTestCase {
-  
-  static var numberOfFailures = 0
-  
-  override class func setUp() {
-    numberOfFailures = Int(ProcessInfo.processInfo.environment["FLAKY_TEST_NUMBER_OF_FAILURES"] ?? "1") ?? 1
-  }
+  private static let numberOfFailuresKey = "flaky_test_number_of_failures"
   
   func testPassIfNoFailuresRemain() {
-    if BullsEyeFlakyTests.numberOfFailures > 0 {
-      BullsEyeFlakyTests.numberOfFailures -= 1
+    let numberOfFailures = UserDefaults.standard.integer(forKey: BullsEyeFlakyTests.numberOfFailuresKey)
+    
+    if numberOfFailures > 0 {
+      UserDefaults.standard.set(numberOfFailures - 1, forKey: BullsEyeFlakyTests.numberOfFailuresKey)
       XCTFail()
     }
   }

--- a/BullsEyeFailingTests/BullsEyeFailingTests.swift
+++ b/BullsEyeFailingTests/BullsEyeFailingTests.swift
@@ -67,6 +67,8 @@ class BullsEyeFailingTests: XCTestCase {
   }
 }
 
+// BullsEyeFlakyTests is a test case that will fail a configurable number of times,
+// then will succeed. This allows to validate the test retry behaviour of the Xcode Test Step.
 class BullsEyeFlakyTests: XCTestCase {
   private static let numberOfFailuresKey = "flaky_test_number_of_failures"
   

--- a/BullsEyeSlowTests/FlakyTests.xctestplan
+++ b/BullsEyeSlowTests/FlakyTests.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "testTimeoutsEnabled" : true
+
   },
   "testTargets" : [
     {

--- a/FlakyTests.xctestplan
+++ b/FlakyTests.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "6ADB41B7-6F06-4C78-B680-E64A7E89882E",
+      "id" : "AC97ACE2-6152-46A5-B2BB-09804ADF9653",
       "name" : "Configuration 1",
       "options" : {
 

--- a/FlakyTests.xctestplan
+++ b/FlakyTests.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {


### PR DESCRIPTION
### Context

Adding test that fails a given times, then suceeds. The number of failures is stored persistently, in the Simulator user defaults.

Resolves: https://bitrise.atlassian.net/browse/STEP-1054

### Decisions

Used User defaults instead of a file for future compatibility.
