### PR TITLE
STEP-1203: Split flaky tests into eventually succeeding & failing

### DIFF
--- a/BullsEye.xcodeproj/project.pbxproj
+++ b/BullsEye.xcodeproj/project.pbxproj
@@ -74,8 +74,9 @@
 		13FB7D18267745440084066F /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		202D822D25D7D57B00778080 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		202D823D25D7D8A300778080 /* URLSessionStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionStub.swift; sourceTree = "<group>"; };
-		47F8605E26932D000039E549 /* FlakyTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FlakyTests.xctestplan; sourceTree = "<group>"; };
 		5394F02421864DF4006E754C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8C6DE9B3269DD0240020B2C9 /* EventuallySucceedingTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EventuallySucceedingTests.xctestplan; sourceTree = "<group>"; };
+		8C6DE9B4269DD04C0020B2C9 /* EventuallyFailingTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EventuallyFailingTests.xctestplan; sourceTree = "<group>"; };
 		D2A5F2001F4A9144005CD714 /* BullsEye.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BullsEye.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2A5F2081F4A9144005CD714 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		D2A5F20A1F4A9144005CD714 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -168,7 +169,8 @@
 		D2A5F1F71F4A9143005CD714 = {
 			isa = PBXGroup;
 			children = (
-				47F8605E26932D000039E549 /* FlakyTests.xctestplan */,
+				8C6DE9B4269DD04C0020B2C9 /* EventuallyFailingTests.xctestplan */,
+				8C6DE9B3269DD0240020B2C9 /* EventuallySucceedingTests.xctestplan */,
 				13055E73267B39B700D762C7 /* FailingTests.xctestplan */,
 				134E1D48267B31C200FEA165 /* ParallelUITests.xctestplan */,
 				13FB7D17267742220084066F /* UnitTests.xctestplan */,

--- a/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
+++ b/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
@@ -45,7 +45,10 @@
             reference = "container:FailingTests.xctestplan">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:FlakyTests.xctestplan">
+            reference = "container:EventuallyFailingTests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:EventuallySucceedingTests.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/BullsEyeFailingTests/BullsEyeFailingTests.swift
+++ b/BullsEyeFailingTests/BullsEyeFailingTests.swift
@@ -67,16 +67,34 @@ class BullsEyeFailingTests: XCTestCase {
   }
 }
 
-// BullsEyeFlakyTests is a test case that will fail a configurable number of times,
-// then will succeed. This allows to validate the test retry behaviour of the Xcode Test Step.
-class BullsEyeFlakyTests: XCTestCase {
-  private static let numberOfFailuresKey = "flaky_test_number_of_failures"
+// A test case that initially fails a predefined number of times then always succeeds.
+// The number of remaining failures is stored in UserDefaults, which is decremented each time the test is executed until it becomes 0.
+// Useful for testing Test Repetition in the Xcode Test step.
+class BullsEyeEventuallySucceedingTests: XCTestCase {
+  private static let numberOfFailuresKey = "eventually_succeeding_test_number_of_failures"
   
   func testPassIfNoFailuresRemain() {
-    let numberOfFailures = UserDefaults.standard.integer(forKey: BullsEyeFlakyTests.numberOfFailuresKey)
+    let numberOfRemainingFailures = UserDefaults.standard.integer(forKey: BullsEyeEventuallySucceedingTests.numberOfFailuresKey)
     
-    if numberOfFailures > 0 {
-      UserDefaults.standard.set(numberOfFailures - 1, forKey: BullsEyeFlakyTests.numberOfFailuresKey)
+    if numberOfRemainingFailures > 0 {
+      UserDefaults.standard.set(numberOfRemainingFailures - 1, forKey: BullsEyeEventuallySucceedingTests.numberOfFailuresKey)
+      XCTFail()
+    }
+  }
+}
+
+// A test case that initially succeeds a predefined number of times then always fails.
+// The number of remaining successes is stored in UserDefaults, which is decremented each time the test is executed until it becomes 0.
+// Useful for testing Test Repetition in the Xcode Test step.
+class BullsEyeEventuallyFailingTests: XCTestCase {
+  private static let numberOfSuccessesKey = "eventually_failing_test_number_of_successes"
+  
+  func testFailIfNoSuccessesRemain() {
+    let numberOfRemainingSuccesses = UserDefaults.standard.integer(forKey: BullsEyeEventuallyFailingTests.numberOfSuccessesKey)
+    
+    if numberOfRemainingSuccesses > 0 {
+      UserDefaults.standard.set(numberOfRemainingSuccesses - 1, forKey: BullsEyeEventuallyFailingTests.numberOfSuccessesKey)
+    } else {
       XCTFail()
     }
   }

--- a/EventuallyFailingTests.xctestplan
+++ b/EventuallyFailingTests.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "3DD0B96D-A634-482D-8C6E-3E2CDD8132EE",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "BullsEyeEventuallySucceedingTests",
+        "BullsEyeFailingTests"
+      ],
+      "target" : {
+        "containerPath" : "container:BullsEye.xcodeproj",
+        "identifier" : "139E88A6268DBCDA0007755C",
+        "name" : "BullsEyeFailingTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/EventuallySucceedingTests.xctestplan
+++ b/EventuallySucceedingTests.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "AC97ACE2-6152-46A5-B2BB-09804ADF9653",
+      "id" : "73BB88C6-6032-4362-8067-72AABD36B3B6",
       "name" : "Configuration 1",
       "options" : {
 
@@ -14,7 +14,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
-        "BullsEyeFlakyTests\/testPassIfNoFailuresRemain()"
+        "BullsEyeEventuallySucceedingTests\/testPassIfNoFailuresRemain()"
       ],
       "target" : {
         "containerPath" : "container:BullsEye.xcodeproj",


### PR DESCRIPTION
## Context
**We are adding Test Repetition support in the Xcode Test step.**
* Test Repetition has 3 modes: `retry_on_failure`, `until_failure` and `up_until_maximum_repetitions`.
* To test `retry_on_failure`, we need tests the initially fail but eventually succeed after a number of tries.
* To test `until_failure`, we need tests that initially succeed but eventually fail after a number of tries.
* To test `up_until_maximum_repetitions`, we need tests that can both succeed and fail a given number of times.

## Description
**Split flaky tests into eventually succeeding & failing.**
* `BullsEyeEventuallySucceedingTests` will help testing `retry_on_failure` Test Repetition Mode.
* `BullsEyeEventuallyFailingTests` will help testing `until_failure` and `up_until_maximum_repetitions` Test Repetition Modes.
* Created distinct test plans for both of these.