### PR TITLE
STEP-1205: Added eventually failing in-memory tests

### DIFF
--- a/BullsEye.xcodeproj/project.pbxproj
+++ b/BullsEye.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		202D822D25D7D57B00778080 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		202D823D25D7D8A300778080 /* URLSessionStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionStub.swift; sourceTree = "<group>"; };
 		5394F02421864DF4006E754C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8C18098226A05EEF00631F74 /* EventuallyFailingInMemoryTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EventuallyFailingInMemoryTests.xctestplan; sourceTree = "<group>"; };
 		8C6DE9B3269DD0240020B2C9 /* EventuallySucceedingTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EventuallySucceedingTests.xctestplan; sourceTree = "<group>"; };
 		8C6DE9B4269DD04C0020B2C9 /* EventuallyFailingTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EventuallyFailingTests.xctestplan; sourceTree = "<group>"; };
 		D2A5F2001F4A9144005CD714 /* BullsEye.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BullsEye.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -169,6 +170,7 @@
 		D2A5F1F71F4A9143005CD714 = {
 			isa = PBXGroup;
 			children = (
+				8C18098226A05EEF00631F74 /* EventuallyFailingInMemoryTests.xctestplan */,
 				8C6DE9B4269DD04C0020B2C9 /* EventuallyFailingTests.xctestplan */,
 				8C6DE9B3269DD0240020B2C9 /* EventuallySucceedingTests.xctestplan */,
 				13055E73267B39B700D762C7 /* FailingTests.xctestplan */,

--- a/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
+++ b/BullsEye.xcodeproj/xcshareddata/xcschemes/BullsEye.xcscheme
@@ -50,6 +50,9 @@
          <TestPlanReference
             reference = "container:EventuallySucceedingTests.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:EventuallyFailingInMemoryTests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/BullsEyeFailingTests/BullsEyeFailingTests.swift
+++ b/BullsEyeFailingTests/BullsEyeFailingTests.swift
@@ -68,7 +68,8 @@ class BullsEyeFailingTests: XCTestCase {
 }
 
 // A test case that initially fails a predefined number of times then always succeeds.
-// The number of remaining failures is stored in UserDefaults, which is decremented each time the test is executed until it becomes 0.
+// The number of remaining failures is stored in UserDefaults, which is decremented each time the test is executed until it reaches 0.
+// After that, the test will always succeed.
 // Useful for testing Test Repetition in the Xcode Test step.
 class BullsEyeEventuallySucceedingTests: XCTestCase {
   private static let numberOfFailuresKey = "eventually_succeeding_test_number_of_failures"
@@ -84,7 +85,8 @@ class BullsEyeEventuallySucceedingTests: XCTestCase {
 }
 
 // A test case that initially succeeds a predefined number of times then always fails.
-// The number of remaining successes is stored in UserDefaults, which is decremented each time the test is executed until it becomes 0.
+// The number of remaining successes is stored in UserDefaults, which is decremented each time the test is executed until it reaches 0.
+// After that, the test will always fail.
 // Useful for testing Test Repetition in the Xcode Test step.
 class BullsEyeEventuallyFailingTests: XCTestCase {
   private static let numberOfSuccessesKey = "eventually_failing_test_number_of_successes"
@@ -94,6 +96,25 @@ class BullsEyeEventuallyFailingTests: XCTestCase {
     
     if numberOfRemainingSuccesses > 0 {
       UserDefaults.standard.set(numberOfRemainingSuccesses - 1, forKey: BullsEyeEventuallyFailingTests.numberOfSuccessesKey)
+    } else {
+      XCTFail()
+    }
+  }
+}
+
+// A test case that initially succeeds a predefined number of times then always succeeds.
+// The number of remaining successes is initialized from UserDefaults then stored in memory.
+// This number is decremented each time a test is executed until it reaches 0. After that, the test will always fail.
+// Can be used to test "Relaunch Tests for Each Repetition" input of the Xcode Test step:
+// - If each test is executed in a new process, then the number of successes is always reset to the value in UserDefaults - therefore tests will never fail (assuming this number is >0).
+// - If tests are executed in the same process, the number of successes has a chance to reach 0 - hence tests will eventually fail.
+class BullsEyeEventuallyFailingInMemoryTests: XCTestCase {
+  private static let numberOfSuccessesKey = "eventually_failing_test_number_of_successes"
+  private static var numberOfRemainingSuccesses = UserDefaults.standard.integer(forKey: BullsEyeEventuallyFailingInMemoryTests.numberOfSuccessesKey)
+  
+  func testFailIfNoSuccessesRemain() {
+    if BullsEyeEventuallyFailingInMemoryTests.numberOfRemainingSuccesses > 0 {
+      BullsEyeEventuallyFailingInMemoryTests.numberOfRemainingSuccesses -= 1
     } else {
       XCTFail()
     }

--- a/EventuallyFailingInMemoryTests.xctestplan
+++ b/EventuallyFailingInMemoryTests.xctestplan
@@ -1,0 +1,27 @@
+{
+  "configurations" : [
+    {
+      "id" : "A3251F97-FBD0-45F1-83A6-FDFE8417A3FB",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "BullsEyeEventuallyFailingInMemoryTests\/testPassIfNoFailuresRemain()"
+      ],
+      "target" : {
+        "containerPath" : "container:BullsEye.xcodeproj",
+        "identifier" : "139E88A6268DBCDA0007755C",
+        "name" : "BullsEyeFailingTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
## Description
**Added eventually failing in-memory tests.**
* Similar to `BullsEyeEventuallyFailingTests`: it succeeds for the first `<number>` of times then always fails.
* However, this test case stores the remaining number of successes in memory, and only uses UserDefaults to initialize this number.
* If tests are executed in a separate process, this number will be reset and will never reach 0: tests will always succeed.
* This will be used to test the "Relaunch Tests for Each Repetition" input in the Xcode Test step.